### PR TITLE
Added BeanStalkd and Redis changeMessageVisibility method.

### DIFF
--- a/src/Simpleue/Queue/BeanStalkdQueue.php
+++ b/src/Simpleue/Queue/BeanStalkdQueue.php
@@ -126,4 +126,9 @@ class BeanStalkdQueue implements Queue
             $this->sendJob($job);
         }
     }
+    
+    public function changeMessageVisibility($job, $visibilityTimeout)
+    {
+        return true;
+    }
 }

--- a/src/Simpleue/Queue/RedisQueue.php
+++ b/src/Simpleue/Queue/RedisQueue.php
@@ -118,4 +118,9 @@ class RedisQueue implements Queue {
             $this->sendJob($job);
         }
     }
+    
+    public function changeMessageVisibility($job, $visibilityTimeout)
+    {
+        return true;
+    }
 }


### PR DESCRIPTION
Since the messageVisibilityTimeout method added for SQS was added to the interface, it was creating an error in Redis and BeanStalkd objects. This solves the error.